### PR TITLE
fix: change cache to lru_cache

### DIFF
--- a/metroscore/utils.py
+++ b/metroscore/utils.py
@@ -1,7 +1,7 @@
 import warnings
 from collections import defaultdict
 from dataclasses import dataclass
-from functools import cache
+from functools import lru_cache
 from typing import Any, Callable, Dict, List, Optional, Tuple
 from uuid import uuid4
 
@@ -260,7 +260,7 @@ def merge_edge_to_node(edge: OSMEdge, node: OSMNode) -> NodeToEdgeMergeResult:
     )
 
 
-@cache
+@lru_cache(maxsize=None)
 def prep_node_tuple(graph: Graph, node_id: int) -> OSMNode:
     return node_id, graph.nodes(data=True)[node_id]
 


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here, if there is one. -->
Closes #64 

## Summary of Changes
<!-- Please list all changes/additions here. -->
- Changes `cache` to `lru_cache(maxsize=None)` to preserve compatibility with Python 3.8 (which doesn't have `cache` implemented yet)

## Test Summary (if applicable)
<!-- Please include a description of how your changes have been tested. -->
`make precommit`
No changelog update necessary since this is a fix

## Merge Checklist

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've run `make precommit` and confirmed it passes with no errors
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [-] I've made any necessary documentation updates
- [-] (If adding new functionality) I've added unit tests to cover the changes
- [-] (If adding new functionality) I've tried out the Metroscore SDK on a new jupyter notebook and confirmed it works as expected.
- [-] I've updated CHANGELOG.md to include my changes. 
