### PR TITLE
chore: add myst_parser to doc requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
 sphinx_rtd_theme
 sphinx == 7.*  # same value as needs_sphinx in /docs/source/conf.py
 sphinx-autodoc-typehints
+myst_parser


### PR DESCRIPTION
## Summary of Changes
<!-- Please list all changes/additions here. -->
- The requirements file readthedocs is using is located at `docs/requirements.txt`, and it needs myst_parser

## Test Summary (if applicable)
`make docs`. Changes will be validated after merge.


## Merge Checklist

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've run `make precommit` and confirmed it passes with no errors
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've made any necessary documentation updates
- [ ] (If adding new functionality) I've added unit tests to cover the changes
- [ ] (If adding new functionality) I've tried out the Metroscore SDK on a new jupyter notebook and confirmed it works as expected.
- [x] I've updated CHANGELOG.md to include my changes. 
