### PR TITLE
chore: remove json syntax highlighting

### DIFF
--- a/metroscore/analysis.py
+++ b/metroscore/analysis.py
@@ -14,7 +14,7 @@ def compute_metroscore(transit_areas, drive_areas, bonus_weight=2.0, return_all=
     Returns:
         pandas.DataFrame: DataFrame with schema:
 
-        .. code-block:: json
+        .. code-block::
 
             {
                 "name": <unique service area names of format "<facility id> : <frombreak> - <tobreak>".>


### PR DESCRIPTION
## Summary of Changes
Readthedocs fails on warning, and the previous build triggered this warning:
```
/home/docs/checkouts/readthedocs.org/user_builds/metroscore/checkouts/latest/metroscore/analysis.py:docstring of metroscore.analysis.compute_metroscore:18: WARNING: Lexing literal_block '{\n    "name": <unique service area names of format "<facility id> : <frombreak> - <tobreak>".>\n    "metroscore": <metroscore of service area.>\n}' as "json" resulted in an error at token: '<'. Retrying in relaxed mode.
```
Which was due to the json syntax highlighting not being supported. As a workaround, this change removes the json predicate in the code block.

## Test Summary (if applicable)
`cd docs && make html` produces output without a warning.


## Merge Checklist

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've run `make precommit` and confirmed it passes with no errors
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've made any necessary documentation updates
- [ ] (If adding new functionality) I've added unit tests to cover the changes
- [ ] (If adding new functionality) I've tried out the Metroscore SDK on a new jupyter notebook and confirmed it works as expected.
- [x] I've updated CHANGELOG.md to include my changes. 
