### PR TITLE
fix: patches prepend with '-'

### DIFF
--- a/metroscore/version.py
+++ b/metroscore/version.py
@@ -8,4 +8,4 @@ _PATCH = "0"
 _SUFFIX = "rc.1"
 
 VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
-VERSION = "{0}.{1}.{2}{3}".format(_MAJOR, _MINOR, _PATCH, _SUFFIX)
+VERSION = "{0}.{1}.{2}-{3}".format(_MAJOR, _MINOR, _PATCH, _SUFFIX)


### PR DESCRIPTION
<!-- To ensure we can review your pull request promptly please complete this template entirely. -->

<!-- Please reference the issue number here, if there is one. -->
Closes #

## Summary of Changes
<!-- Please list all changes/additions here. -->
- Prepends `-` to the patch, so that a version will be `1.0.0-rc.1` and not `1.0.0rc.1` as per [semver](https://semver.org/spec/v2.0.0.html) rules

## Test Summary (if applicable)
<!-- Please include a description of how your changes have been tested. -->


## Merge Checklist

<!-- Please complete this checklist BEFORE submitting your PR to speed along the review process. -->
- [x] I've run `make precommit` and confirmed it passes with no errors
- [x] I've read and followed all steps in the [Making a pull request](https://github.com/allenai/beaker-py/blob/main/CONTRIBUTING.md#making-a-pull-request)
    section of the `CONTRIBUTING` docs.
- [x] I've made any necessary documentation updates
- [ ] (If adding new functionality) I've added unit tests to cover the changes
- [ ] (If adding new functionality) I've tried out the Metroscore SDK on a new jupyter notebook and confirmed it works as expected.
- [x] I've updated CHANGELOG.md to include my changes. 
